### PR TITLE
Update ssllabs.py

### DIFF
--- a/ssllabs.py
+++ b/ssllabs.py
@@ -296,7 +296,7 @@ class SSLLabsAssessment(object):
                 else:
                     return self._get_all_results()
             elif _status.get('status') == 'ERROR':
-                print('An error occured: {}'.format(_status.get('errors')))
+                print('An error occured: {}'.format(_status.get('statusMessage')))
                 return
             else:
                 continue
@@ -335,7 +335,7 @@ class SSLLabsAssessment(object):
                 elif _host_status == 'READY':
                     return self._get_all_results()
                 elif _host_status == 'ERROR':
-                    print('[ERROR] An error occured: {}'.format(_status.get('errors')))
+                    print('[ERROR] An error occured: {}'.format(_status.get('statusMessage')))
                     return
                 elif _host_status == 'DNS':
                     if self.VERBOSE:


### PR DESCRIPTION
Update errors to `statusMessage`per api documentation:

> **statusMessage** - status message in English. When status is ERROR, this field will contain an error message.

and `errors`is for incorrect API invoking:

> When an API call is incorrectly invoked, it will cause an error response to be sent back. The response will include an array of error messages. For example:

```
{"errors":[{"field":"host","message":"qp.mandatory"}]}
```

> The field value references the API parameter name that has an incorrect value. The message value will tell you what the issue is. It is also possible to receive errors without the field parameter set; such messages will usually refer to the request as a whole.
