### PR TITLE
Fix version number fetching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,29 @@
 from setuptools import setup
-from ssllabs import vars
+
+# Read the value of the 'version' variable from ssllabs/vars.py without importing it.
+# Importing vars.py would cause the installation to fail if dependencies of ssllabs/__init__.py are not met.
+
+import pathlib
+import re
+
+version = None
+
+with open(pathlib.Path(__file__).parent / 'ssllabs' / 'vars.py') as f:
+    for line in f:
+        match = re.match(r'version = \'(.*)\'', line)
+        if match:
+            version = match.group(1)
+            break
+
+if not version:
+    raise RuntimeError('Could not determine version from ssllabs/vars.py')
 
 setup(name='python-ssllabs',
-    version=vars.version,
+    version=version,
     packages=['ssllabs'],
     scripts=['ssllabs-cli.py'],
     install_requires=['requests'],
     url='https://github.com/takeshixx/python-ssllabs',
-    license=vars.license,
+    license='Apache 2.0',
     author='takeshix',
     author_email='takeshix@adversec.com')

--- a/ssllabs/vars.py
+++ b/ssllabs/vars.py
@@ -1,2 +1,1 @@
 version = '1.4'
-license = 'Apache 2.0'


### PR DESCRIPTION
The current way of importing the version number from the package itself causes a problem: requests must be installed in order to import ssllabs/vars.py which implicitly executes ssllabs/__init__.py, but requests may not be installed already.

See here for details: https://stackoverflow.com/posts/7071358/revisions